### PR TITLE
Add consistent-type-imports, prefer-const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.1.0
+* consistent-type-imports, prefer-const をルールに追加
+
 ## 1.0.0
 * eslint 関連のパッケージを最新版(eslint v8)に更新
 * lint のテストを追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.1.0
-* consistent-type-imports, prefer-const をルールに追加
+* @typescript-eslint/consistent-type-imports, prefer-const をルールに追加
 
 ## 1.0.0
 * eslint 関連のパッケージを最新版(eslint v8)に更新

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ module.exports = {
 			"args": "all",
 			"argsIgnorePattern": "^_"
 		}],
+		"@typescript-eslint/consistent-type-imports": "error",
 		"camelcase": "off",
 		"curly": "off",
 		"dot-notation": "error",
@@ -166,6 +167,7 @@ module.exports = {
 		"no-unused-expressions": "error",
 		"no-unused-labels": "error",
 		"no-var": "error",
+		"prefer-const": "error",
 		"radix": "error",
 		"spaced-comment": ["error", "always", { "markers": ["/"] }],
 		"keyword-spacing": ["error"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "eslint-plugin-import": "^2.25.0",
-        "eslint-plugin-jest": "^25.2.0"
+        "eslint-plugin-jest": "^26.1.1"
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -268,6 +268,104 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
+      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.12.1",
+        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/typescript-estree": "5.12.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
+      "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/visitor-keys": "5.12.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
+      "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
+      "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/visitor-keys": "5.12.1",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
+      "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.12.1",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -792,22 +890,25 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.2.tgz",
-      "integrity": "sha512-frn5yhOF60U4kcqozO3zKTNZQUk+mfx037XOy2iiYL8FhorEkuCuL3/flzKcY1ECDP2WYT9ydmvlO3fRW9o4mg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
+      "integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.0.0"
+        "@typescript-eslint/utils": "^5.10.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
           "optional": true
         }
       }
@@ -2334,6 +2435,63 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/utils": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
+      "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.12.1",
+        "@typescript-eslint/types": "5.12.1",
+        "@typescript-eslint/typescript-estree": "5.12.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.12.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
+          "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.12.1",
+            "@typescript-eslint/visitor-keys": "5.12.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.12.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
+          "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.12.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
+          "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.12.1",
+            "@typescript-eslint/visitor-keys": "5.12.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.12.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
+          "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.12.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        }
+      }
+    },
     "@typescript-eslint/visitor-keys": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
@@ -2753,12 +2911,12 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.2.tgz",
-      "integrity": "sha512-frn5yhOF60U4kcqozO3zKTNZQUk+mfx037XOy2iiYL8FhorEkuCuL3/flzKcY1ECDP2WYT9ydmvlO3fRW9o4mg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
+      "integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "^5.0.0"
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/eslint-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "akashic-gamesリポジトリで共通的に利用するeslintのプリセットです。",
   "main": "index.js",
   "scripts": {
@@ -23,13 +23,13 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "eslint-plugin-import": "^2.25.0",
-    "eslint-plugin-jest": "^25.2.0"
+    "eslint-plugin-jest": "^26.1.1"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "eslint": "^8.1.0",
     "eslint-plugin-import": "^2.25.0",
-    "eslint-plugin-jest": "^25.2.0"
+    "eslint-plugin-jest": "^25.2.0 || ^26.0.0"
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"

--- a/test/LintTest.ts
+++ b/test/LintTest.ts
@@ -1,3 +1,4 @@
+import type { TestConfig } from "./TestConfig";
 
 // naming-convention
 // 変数のcamelCase UpperCase での宣言, 接頭 `_` の変数のエラー除外
@@ -6,6 +7,9 @@ const UPPER_CASE = "";
 let camelCase: number;
 const isTest = true;
 const _snake_case = ""; // 変数のスネークケースはエラーとなるが 接頭に `_` があるため除外される
+const _config: TestConfig = {
+	type: "foo"
+};
 
 // type, Enum, interface class の PascalCase での宣言
 type TypeTest = "";

--- a/test/LintTest.ts
+++ b/test/LintTest.ts
@@ -1,4 +1,4 @@
-import type { TestConfig } from "./TestConfig";
+import type { TestModule } from "./TestModule";
 
 // naming-convention
 // 変数のcamelCase UpperCase での宣言, 接頭 `_` の変数のエラー除外
@@ -7,7 +7,7 @@ const UPPER_CASE = "";
 let camelCase: number;
 const isTest = true;
 const _snake_case = ""; // 変数のスネークケースはエラーとなるが 接頭に `_` があるため除外される
-const _config: TestConfig = {
+const _module: TestModule = {
 	type: "foo"
 };
 

--- a/test/LintTest.ts
+++ b/test/LintTest.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */ // 宣言のみのため unused-vars を無効
 const UPPER_CASE = "";
 let camelCase: number;
-let isTest = true;
+const isTest = true;
 const _snake_case = ""; // 変数のスネークケースはエラーとなるが 接頭に `_` があるため除外される
 
 // type, Enum, interface class の PascalCase での宣言

--- a/test/TestConfig.ts
+++ b/test/TestConfig.ts
@@ -1,0 +1,5 @@
+// import ルールのテスト用
+export interface TestConfig {
+	type: "foo" | "hoge";
+}
+

--- a/test/TestModule.ts
+++ b/test/TestModule.ts
@@ -1,5 +1,5 @@
 // import ルールのテスト用
-export interface TestConfig {
+export interface TestModule {
 	type: "foo" | "hoge";
 }
 


### PR DESCRIPTION
## 概要

ルールに `consistent-type-imports`, `prefer-const` を追加します。

- consistent-type-imports: `import type` 使用の標準化
- prefer-const: 再代入されない変数を `const` にします。
   (no-vars での --fix は強制的に `var` -> `let` とするため prefer-const で const で問題ないところは const へ修正されます) 